### PR TITLE
Uploads are split into chunks & sent via socketio.

### DIFF
--- a/client/dialogs.ts
+++ b/client/dialogs.ts
@@ -1,6 +1,43 @@
 
 import { type Controller, Dialog } from '@fizz/expert-client';
 import { type Dashboard } from './dashboard';
+import { type Uploader } from './uploader';
+
+
+export class UploadDialog extends Dialog {
+    declare ctrlr: Uploader;
+    private inputNode: HTMLInputElement;
+    private uploadBtn: HTMLButtonElement;
+
+    constructor(ctrlr: Uploader, template = 'upload', id = 'exp-dlg-upload') {
+        super(ctrlr, template, id);
+    }
+
+    async init() {
+        await super.init();
+        this.titlebar = 'Upload Bundle';
+        this.inputNode = this.node.querySelector('.exp-dlg-upload-input')!;
+        this.uploadBtn = this.node.querySelector('.exp-dlg-upload-btn')!;
+        this.inputNode.addEventListener('change', 
+            () => this.ctrlr.didSelectFiles(this.inputNode.files!));
+        this.uploadBtn.addEventListener('click', 
+            async () => await this.ctrlr.upload());
+        return this;
+    }
+
+    async show() {
+        this.setButtons([{tag: 'cancel', text: 'Close'}]);
+        return await super.makeVisible();
+    }
+
+    enableButton() {
+        this.uploadBtn.disabled = false;
+    }
+
+    disableButton() {
+        this.uploadBtn.disabled = true;
+    }
+}
 
 export class SingleSelectorDialog extends Dialog {
     selectNode: HTMLSelectElement;

--- a/expert/server.py
+++ b/expert/server.py
@@ -190,15 +190,9 @@ class Server:
     def _add_routes(self):
         first_request_setup_complete = False
 
-        # @e.app.route(f'/{self.cfg["url_prefix"]}/socket.io-client')
-        # def socketio():
-        #     return send_from_directory(
-        #         e.expert_path / 'node_modules/socket.io-client/dist', 'socket.io.js')
-
-        # @e.app.route(f'/expert-client')
-        # def expert_client():
-        #     return send_from_directory(
-        #         e.expert_path / 'node_modules/@fizz/expert-client/dist', 'index.js')
+        @e.app.route('/client/<path:subpath>')
+        def expert_ts(subpath):
+            return send_from_directory(e.expert_path / 'client', subpath)
 
         @e.app.route(f'/{self.cfg["url_prefix"]}/js/<path:subpath>')
         def js(subpath):

--- a/expert/static/css/dboard.css
+++ b/expert/static/css/dboard.css
@@ -136,4 +136,10 @@ body {
   padding: 0.5rem;
 }
 
+.exp-dlg-upload-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 /*# sourceMappingURL=dboard.css.map */

--- a/expert/static/js/dialog.js
+++ b/expert/static/js/dialog.js
@@ -8,10 +8,15 @@ function elts(...ids) {
     }
     return dom;
 }
-async function callApi(socket, ...params) {
-    const p = new Promise(resolve => {
-        socket.emit('call_api', ...params, (resp) => {
-            resolve(resp);
+async function callApi(socket, cmd, params = []) {
+    const p = new Promise((resolve, reject) => {
+        socket.emit('call_api', cmd, ...params, (resp) => {
+            if (Object.hasOwn(resp, 'val')) {
+                resolve(resp.val);
+            }
+            else {
+                reject(resp.err);
+            }
         });
     });
     return p;
@@ -38,8 +43,8 @@ class Controller {
     async _onSocketConnectError() {
         console.log("socket connection error");
     }
-    async api(cmd, ...params) {
-        return await callApi(this._socket, cmd, ...params);
+    async api(cmd, params = []) {
+        return await callApi(this._socket, cmd, params);
     }
 }
 
@@ -68,7 +73,7 @@ class Overlay extends View {
         this.visible = false;
     }
     async init() {
-        const content = await this.ctrlr.api('load_template', this.template);
+        const content = await this.ctrlr.api('load_template', [this.template]);
         this.node.innerHTML = content;
         this.contentNode = this.node.querySelector('.exp-overlay-content');
         return this;

--- a/expert/static/js/task.js
+++ b/expert/static/js/task.js
@@ -48,7 +48,7 @@ class Task extends Controller {
                 await this._nextHook();
             }
             this.disableNext();
-            await this._nav('next_page', this.response);
+            await this._nav('next_page', [this.response]);
         });
         if (this.returnBtn) {
             this.returnBtn.addEventListener('click', async () => {
@@ -62,13 +62,13 @@ class Task extends Controller {
         if (this.domVars.exp_tool_mode === 'True') {
             this.prevBtn.addEventListener('click', async () => {
                 this.prevBtn.disabled = true;
-                await this._nav('prev_page', this.response);
+                await this._nav('prev_page', [this.response]);
                 this.prevBtn.disabled = false;
             });
             this.navSelect.addEventListener('change', async () => {
                 const idx = this.navSelect.selectedIndex;
                 if (idx) {
-                    await this._nav('goto', this.vars['exp_nav_items'][idx - 1], this.response);
+                    await this._nav('goto', [this.vars['exp_nav_items'][idx - 1], this.response]);
                 }
             });
         }
@@ -79,8 +79,8 @@ class Task extends Controller {
     set nextHook(h) {
         this._nextHook = h;
     }
-    async api(cmd, ...params) {
-        const { val, err } = await super.api(cmd, ...params);
+    async api(cmd, params = []) {
+        const { val, err } = await super.api(cmd, params);
         if (err) {
             if (this.errorOverlay) {
                 this.errorOverlay.makeVisible();
@@ -107,8 +107,8 @@ class Task extends Controller {
             this.nextBtn.disabled = cursor === num_tasks;
         }
     }
-    async _nav(cmd, ...params) {
-        let vars = await this.api(cmd, ...params);
+    async _nav(cmd, params = []) {
+        let vars = await this.api(cmd, params);
         if (vars['task_type'] === this.vars['task_type'] &&
             vars['task_script'] === this.vars['task_script']) {
             this.vars = vars;

--- a/expert/templates/dashboard.html.jinja
+++ b/expert/templates/dashboard.html.jinja
@@ -22,8 +22,6 @@
             <span id="run-info"></span>
         </div>
         <div id="controls">
-            <input type="file" id="file-input" class="exp-hidden"
-            webkitdirectory multiple>
             <button type="button" id="upload-btn" disabled>
                 Upload Bundle︎
             </button>

--- a/expert/templates/upload_dialog.html.jinja
+++ b/expert/templates/upload_dialog.html.jinja
@@ -1,0 +1,11 @@
+
+{% extends 'dialog.html.jinja' %}
+
+{% block exp_dlg_content %}
+    <div class="exp-dlg-upload-wrapper">
+        <input type="file" class="exp-dlg-upload-input" webkitdirectory multiple>
+        <button type="button" class="exp-dlg-upload-btn" disabled>
+            Upload
+        </button>
+    </div>
+{% endblock %}

--- a/expert_cfg.json
+++ b/expert_cfg.json
@@ -5,5 +5,7 @@
     "bundles_dir": "bundles",
     "monitor_check_interval": 10,
     "dashboard_code": "96Q28aD7JgZ2np2-M7tQQQ",
-    "dashboard_favicon": "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><rect width=%22100%22 height=%22100%22 fill=%22green%22/><text y=%22.9em%22 font-size=%2290%22>🧪</text></svg>"
+    "dashboard_favicon": "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><rect width=%22100%22 height=%22100%22 fill=%22green%22/><text y=%22.9em%22 font-size=%2290%22>🧪</text></svg>",
+    "upload_chunk_size_kib": 128,
+    "simultaneous_chunk_uploads": 50
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@fizz/expert-client": "^0.4.2"
+        "@fizz/expert-client": "^0.6.0"
       },
       "devDependencies": {
         "@rollup/plugin-eslint": "9.0.3",
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@fizz/expert-client": {
-      "version": "0.4.2",
-      "resolved": "https://npm.fizz.studio/@fizz/expert-client/-/expert-client-0.4.2.tgz",
-      "integrity": "sha512-WrkEN3knZmgkC8y3BW3H7SKKtr2SXZD6Fm2IOtV0H/mCZ6PzJen4TsbDMkmGXJjbqwl5Ik51y70UYCwgbeFDRg=="
+      "version": "0.6.0",
+      "resolved": "https://npm.fizz.studio/@fizz/expert-client/-/expert-client-0.6.0.tgz",
+      "integrity": "sha512-EiRs5iK0on0crkQ2dGzT9/aJxlPDE2mT9idhsW/WvVNJkvgWFi8XCFPtg4DW9TtrLviAV/WCUBNYWXKs97nTmQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -1622,9 +1622,9 @@
       }
     },
     "@fizz/expert-client": {
-      "version": "0.4.2",
-      "resolved": "https://npm.fizz.studio/@fizz/expert-client/-/expert-client-0.4.2.tgz",
-      "integrity": "sha512-WrkEN3knZmgkC8y3BW3H7SKKtr2SXZD6Fm2IOtV0H/mCZ6PzJen4TsbDMkmGXJjbqwl5Ik51y70UYCwgbeFDRg=="
+      "version": "0.6.0",
+      "resolved": "https://npm.fizz.studio/@fizz/expert-client/-/expert-client-0.6.0.tgz",
+      "integrity": "sha512-EiRs5iK0on0crkQ2dGzT9/aJxlPDE2mT9idhsW/WvVNJkvgWFi8XCFPtg4DW9TtrLviAV/WCUBNYWXKs97nTmQ=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "doc": "rimraf ./docs/* && jsdoc -c .jsdoc/.jsdoc.html.json && jsdoc -c .jsdoc/.jsdoc.md.json"
   },
   "dependencies": {
-    "@fizz/expert-client": "^0.4.2"
+    "@fizz/expert-client": "^0.6.0"
   },
   "devDependencies": {
     "@rollup/plugin-eslint": "9.0.3",

--- a/sass/dboard.scss
+++ b/sass/dboard.scss
@@ -165,3 +165,9 @@ body {
         }
     }
 }
+
+.exp-dlg-upload-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}


### PR DESCRIPTION
- Closes #24.
- Reworked the upload UI to avoid creating unresolved promises and better conform to how file inputs are supposed to work.
- The client now won't upload .DS_Store files, or anything in a __pycache__ folder.
- The server will refuse to save <bundle>/runs or /profiles (already blocked by client, but).
- New expert_cfg.json options for upload chunk size and number of simultaneous chunk uploads.
- Server provisionally serves /client/*.ts sources, which is useful for browser debugging.